### PR TITLE
Separate chain calls

### DIFF
--- a/tests/AssetsTest.php
+++ b/tests/AssetsTest.php
@@ -48,10 +48,12 @@ final class AssetsTest extends TestCase
     {
         $bundle = new $bundleClass();
 
-        [$bundle->basePath, $bundle->baseUrl] = $this->assetManager->getPublish()->publish(
-            $this->assetManager,
-            $bundle
-        );
+        [$bundle->basePath, $bundle->baseUrl] = $this->assetManager
+            ->getPublish()
+            ->publish(
+                $this->assetManager,
+                $bundle
+            );
 
         foreach ($bundle->js as $filename) {
             $publishedFile = $bundle->basePath . DIRECTORY_SEPARATOR . $filename;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Readability fix  | according to https://github.com/yiisoft/docs/issues/155, chain calls must be put on separate lines.